### PR TITLE
Update FreeCAD macro path instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Version **2.0** introduces a unified workflow with improved report messaging and
 ## Installation
 
 1. Download `MeshToBody_2.0.py`  
-2. Place it in your FreeCAD macros directory (`Edit > Preferences > General > Macro`)  
+2. Place it in your FreeCAD macros directory (`Edit > Preferences > Python > Macro > Macro path`)  
 3. Restart FreeCAD if already running
 
 ## Usage


### PR DESCRIPTION
When I was going through the README instructions, the Macro path setting was in a slightly different location in the Preferences pane: `Edit > Preferences > Python > Macro > Macro path`. I'm v1.0.2.

Just wanted to clarify this in your instructions for any other beginners like myself :)

If the location of this setting has changed in v1.1 (I haven't checked), then feel free to close this!